### PR TITLE
Реализация кеширования отдельных текстов задач

### DIFF
--- a/cgi-bin/main.pl
+++ b/cgi-bin/main.pl
@@ -279,6 +279,7 @@ sub contests_edit_save
         $edit_cid
     );
     $dbh->commit;
+    CATS::StaticPages::invalidate_problem_text(cid => $edit_cid);
     # если переименовали текущий турнир, сразу изменить заголовок окна
     if ($edit_cid == $cid)
     {
@@ -1114,6 +1115,8 @@ sub problems_frame_jury_action
             $cpid) or return;
 
         $dbh->do(qq~DELETE FROM contest_problems WHERE id = ?~, undef, $cpid);
+        CATS::StaticPages::invalidate_problem_text(cid => $old_contest);
+        
         my ($ref_count) = $dbh->selectrow_array(qq~
             SELECT COUNT(*) FROM contest_problems WHERE problem_id = ?~, undef, $pid);
         if ($ref_count)


### PR DESCRIPTION
Реюзается все описанное в CATS/StaticPages.pm, но подправлен invalidate_problem_text, чтобы очищать кеш отдельных задач по pid и cpid. В теории, казалось бы, надо было бы ещё сделать по cid, но в местах вызова invalidate_problem_text(cid => $cid) доступен отдельно $cpid, поэтому эти вызовы просто дополнены строчками invalidate_problem_text(cpid => $cpid). invalidate делается во всех случаях, что и для принтабельного списка задач, кроме одного случая -- добавление новой задачи, т.к. гарантируется, что её кеша ещё нет. В интерфейсе поведение сделано таким же как и для списка задач - жюри смотрят некешированную версию, юзеры - кешированную.
