### PR TITLE
Security: Only jury can use retest functionality

### DIFF
--- a/cgi-bin/CATS/Console.pm
+++ b/cgi-bin/CATS/Console.pm
@@ -536,6 +536,7 @@ sub graphs
 
 sub retest_submissions
 {
+    $is_jury or return;
     my ($selection) = @_;
     my $count = 0;
     my @sanitized_runs = grep $_ ne '', split /\D+/, $selection;


### PR DESCRIPTION
At least we should check just for `is_jury`. Possibly we should check,
that run is doing against task in contest, that current user is jury in.
