### PR TITLE
Fix bug: move 'param_on' function from CATS::Utils to CATS::Web

### DIFF
--- a/cgi-bin/CATS/UI/Compilers.pm
+++ b/cgi-bin/CATS/UI/Compilers.pm
@@ -3,13 +3,12 @@ package CATS::UI::Compilers;
 use strict;
 use warnings;
 
-use CATS::Web qw(param url_param);
+use CATS::Web qw(param param_on url_param);
 use CATS::DB;
 use CATS::Misc qw(
     $t $is_jury $is_root
     init_template init_listview_template msg res_str url_f
     order_by define_columns attach_listview references_menu);
-use CATS::Utils qw(param_on);
 
 sub edit_frame
 {

--- a/cgi-bin/CATS/UI/Contests.pm
+++ b/cgi-bin/CATS/UI/Contests.pm
@@ -3,7 +3,7 @@ package CATS::UI::Contests;
 use strict;
 use warnings;
 
-use CATS::Web qw(param url_param redirect);
+use CATS::Web qw(param param_on url_param redirect);
 use CATS::DB;
 use CATS::Constants;
 use CATS::Misc qw(
@@ -11,7 +11,7 @@ use CATS::Misc qw(
     init_template init_listview_template msg res_str url_f auto_ext
     order_by define_columns attach_listview);
 use CATS::Config qw(cats_dir);
-use CATS::Utils qw(url_function param_on coalesce date_to_iso);
+use CATS::Utils qw(url_function coalesce date_to_iso);
 use CATS::Data qw(:all);
 use CATS::StaticPages;
 use CATS::RankTable;

--- a/cgi-bin/CATS/UI/Judges.pm
+++ b/cgi-bin/CATS/UI/Judges.pm
@@ -3,13 +3,12 @@ package CATS::UI::Judges;
 use strict;
 use warnings;
 
-use CATS::Web qw(param url_param);
+use CATS::Web qw(param param_on url_param);
 use CATS::DB;
 use CATS::Misc qw(
     $t $is_jury $is_root
     init_template init_listview_template msg res_str url_f
     order_by define_columns attach_listview references_menu);
-use CATS::Utils qw(param_on);
 
 
 sub edit_frame

--- a/cgi-bin/CATS/UI/Users.pm
+++ b/cgi-bin/CATS/UI/Users.pm
@@ -4,14 +4,14 @@ use strict;
 use warnings;
 
 use Data::Dumper;
-use CATS::Web qw(param url_param);
+use CATS::Web qw(param param_on url_param);
 use CATS::DB;
 use CATS::Constants;
 use CATS::Misc qw(
     $t $is_jury $is_root $is_team $sid $cid $uid $contest $is_virtual $settings
     init_template init_listview_template msg res_str url_f auto_ext
     order_by define_columns attach_listview);
-use CATS::Utils qw(url_function param_on);
+use CATS::Utils qw(url_function);
 use CATS::Web qw(redirect);
 use CATS::Data qw(:all);
 use CATS::User;

--- a/cgi-bin/CATS/Utils.pm
+++ b/cgi-bin/CATS/Utils.pm
@@ -22,7 +22,6 @@ BEGIN {
         url_function
         state_to_display
         source_hash
-        param_on
         date_to_iso
         encodings
         source_encodings
@@ -422,12 +421,6 @@ sub balance_tags
 sub source_hash
 {
     Digest::MD5::md5_hex(Encode::encode_utf8($_[0]));
-}
-
-
-sub param_on
-{
-    return (param($_[0]) || '') eq 'on';
 }
 
 

--- a/cgi-bin/CATS/Web.pm
+++ b/cgi-bin/CATS/Web.pm
@@ -17,6 +17,7 @@ BEGIN {
         init_request
         url_param
         param
+        param_on
         encoding_param
         redirect
         headers
@@ -70,6 +71,12 @@ sub param
     _param(@_); # trick to change param implementation at runtime
 }
 *url_param = \&param;
+
+
+sub param_on
+{
+    return (param($_[0]) || '') eq 'on';
+}
 
 
 sub save_uploaded_file

--- a/cgi-bin/main.pm
+++ b/cgi-bin/main.pm
@@ -35,7 +35,7 @@ use CATS::Constants;
 use CATS::BinaryFile;
 use CATS::DevEnv;
 use CATS::Misc qw(:all);
-use CATS::Utils qw(coalesce url_function state_to_display param_on);
+use CATS::Utils qw(coalesce url_function state_to_display);
 use CATS::Data qw(:all);
 use CATS::IP;
 use CATS::Problem::Text;


### PR DESCRIPTION
It's necessary because 'param_on' depends on the 'param' which is located in CATS::Web