### PR TITLE
Add missing fields to console_content.json.tt

### DIFF
--- a/tt/console_content.json.tt
+++ b/tt/console_content.json.tt
@@ -15,6 +15,8 @@
 "submit_time": "[% c.time_iso %]",
 "state": [% c.request_state %],
 "status": "[% c.request_state_text %]",
+[% IF c.failed_test %]"failed_test": [% c.failed_test %],
+[% END -%]
 [% IF c.points.defined %]"points": [% c.points %],
 [% END -%]
 "problem_title" : "[% c.problem_title | $Javascript %]"

--- a/tt/console_content.json.tt
+++ b/tt/console_content.json.tt
@@ -6,6 +6,8 @@
 [% IF c.is_submit_result -%]
 "type": "submit",
 "id": [% c.id %],
+[% IF is_jury %]"ip": "[% c.last_ip_short %]",
+[% END -%]
 "contest_id": [% c.contest_id %],
 "problem_id": [% c.problem_id %],
 "team_id": [% c.team_id %],
@@ -23,6 +25,8 @@
 [% END -%]
 [% IF c.is_message -%]
 "type": "message",
+[% IF is_jury %]"ip": "[% c.last_ip_short %]",
+[% END -%]
 "team_id": [% c.team_id %],
 "text": "[% c.message_text | $Javascript %]"
 [% END -%]


### PR DESCRIPTION
Fields "failed_attempt" and "ip" (for jury) were missing from the JSON, though they are available in HTML version. This pull request adds missing fields