### PR TITLE
Deployment: fixed database aliases not working in Firebird 3.x

### DIFF
--- a/deploy.bash
+++ b/deploy.bash
@@ -219,7 +219,10 @@ if [[ ($step =~ (^|,)7(,|$) || $step == "*") && $FB_DEV_VERSION ]]; then
 	CONFIG_ROOT="${CATS_ROOT}/cgi-bin/cats-problem/CATS"
 	CREATE_DB_NAME="create_db.sql"
 	CREATE_DB_ROOT="${CATS_ROOT}/sql/interbase"
-	FB_ALIASES="/etc/firebird/${FB_DEV_VERSION}/aliases.conf"
+	FB_ALIASES="/etc/firebird/${FB_DEV_VERSION}/"
+	# aliases.conf is replaced by databases.conf in firebird 3.x
+	FB_ALIASES=$FB_ALIASES$([ `echo "$FB_DEV_VERSION < 3.0" | bc` -eq 1 ] && 
+						       echo "aliases.conf" || echo "databases.conf")
 
 	CONFIG="$CONFIG_ROOT/$CONFIG_NAME"
 	cp "$CONFIG_ROOT/${CONFIG_NAME}.template" $CONFIG
@@ -252,7 +255,7 @@ if [[ ($step =~ (^|,)7(,|$) || $step == "*") && $FB_DEV_VERSION ]]; then
 	read -e -p "Username: " db_user
 	read -e -p "Password: " db_pass
 
-	sudo sh -c "echo 'cats=$path_to_db' > $FB_ALIASES"
+	sudo sh -c "echo 'cats = $path_to_db' >> $FB_ALIASES"
 
 	if [[ "$path_to_db" = "$def_path_to_db" ]]; then
 		mkdir "$HOME/.cats"


### PR DESCRIPTION
The file aliases.conf is [replaced](https://firebirdsql.org/file/documentation/release_notes/html/en/3_0/rnfb30-compat-aliasesconf.html) by databases.conf in the Firebird root directory (Firebird 3.0 and higher).
