### PR TITLE
problem_text: Show code of participant if jury and uid in query params

### DIFF
--- a/cgi-bin/CATS/Router.pm
+++ b/cgi-bin/CATS/Router.pm
@@ -344,7 +344,7 @@ my $main_routes = {
         source => upload, source_text => str, problem_id => integer, de_id => qr/\d+|by_extension/,
     ],
     api_get_sources_info => [ \&CATS::UI::RunDetails::get_sources_info_api,
-        problem_id => integer, contest_id => integer, src_enc => encoding_default('UTF-8'),
+        problem_id => integer, contest_id => integer, src_enc => encoding_default('UTF-8'), uid => integer,
     ],
     problem_text => [ \&CATS::UI::Problems::problem_text_frame,
         pid => integer, cpid => integer, cid => integer,

--- a/cgi-bin/CATS/UI/RunDetails.pm
+++ b/cgi-bin/CATS/UI/RunDetails.pm
@@ -452,7 +452,7 @@ sub get_sources_info_api {
         SELECT id FROM reqs
         WHERE problem_id = ? AND account_id = ? AND contest_id = ?
         ORDER BY submit_time DESC~, { Slice => {} },
-        $p->{problem_id}, $uid, $cid);
+        $p->{problem_id}, $is_jury && $p->{uid} ? $p->{uid} : $uid, $cid);
     $rid or return;
     my $sources_info = get_sources_info($p, request_id => $rid, get_source => 1, encode_source => 1);
     $p->print_json(CATS::ReqDetails::prepare_sources($p, $sources_info));

--- a/tt/problem_text.html.tt
+++ b/tt/problem_text.html.tt
@@ -492,6 +492,7 @@ function get_sources_info_api() {
   var editor = ace.edit(get_editor(form).attr('data-id'));
   if (!ace || !editor) return;
   var request_url = '[% href_get_sources_info %]' + ';sid=' + sid;
+  if (uid) request_url += ';uid=' + uid;
   $.ajax({
     url: request_url,
     data: { problem_id: form.find('input[name=problem_id]').val() },


### PR DESCRIPTION
Allow jury to see the source code of participant when they follow the link "problem_text" from view_source page.

1. Modify request: add uid if it's in query parameters

2. If current user is jury and uid in query parameters -- return sources info for that user