### PR TITLE
js/editor: fix link match

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -344,7 +344,7 @@ ace.define('hoverlink', [], function(require, exports, module) {
       var session = editor.session;
       var line = session.getLine(row);
 
-      var match = this.getMatchAround(/https?:\/\/[^\s'']+/g, line, column);
+      var match = this.getMatchAround(/https?:\/\/[^\s''<]+/g, line, column);
       if (!match)
           return;
 


### PR DESCRIPTION
exclude left inequality sign to avoid tags matching
the previous behavior was catching tags to the right, like so: `https://github.com/klenin/cats-main/commit/dce22c8348808959881ed7d6852c520a41e47c9a</code></p>`