### PR TITLE
Changed year from 2018 to 2020 in footer in docs

### DIFF
--- a/docs/tt/footer.tti
+++ b/docs/tt/footer.tti
@@ -18,7 +18,7 @@
   <td>
     <a href="https://github.com/klenin/cats-main">[% PROCESS includes/github_icon.tti %] [% capt.development %]</a>[%
     %]<a href="index.[% lang %].html">[% capt.docs %]</a>[%
-    %]<a href="authors.html">&copy; 2002-2018 [% capt.authors %]</a>
+    %]<a href="authors.html">&copy; 2002-2020 [% capt.authors %]</a>
   </td>
 </tr>
 <tr class="footer2">


### PR DESCRIPTION
There is a typo in year in footer in docs section.
It is 2020 now. But 2018 is presented.

![image](https://user-images.githubusercontent.com/44186258/95677552-99d45300-0c09-11eb-8d3d-cdb429083316.png)

The only one commit in this pull request fixes this typo.